### PR TITLE
feat!: Re-introduce renderer trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-img"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "ansi_colours",
  "ansi_term",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "ascii-img-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "ascii-img",
  "clap",
@@ -192,9 +192,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitreader"
@@ -255,9 +255,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -373,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80c3f80814db85397819d464bb553268992c393b4b3b5554b89c1655996d5926"
 dependencies = [
  "av-data",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "dav1d-sys",
  "static_assertions",
 ]
@@ -1312,7 +1312,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/ascii-img-cli/Cargo.toml
+++ b/ascii-img-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii-img-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Command-line tool for using ascii-img"
 license = "MPL-2.0"
@@ -28,6 +28,6 @@ tiff = ["image/tiff"]
 webp = ["image/webp"]
 
 [dependencies]
-ascii-img = { version = "0.2.2", path = "../ascii-img", features = ["rayon"] }
+ascii-img = { version = "0.3.0", path = "../ascii-img", features = ["rayon"] }
 clap = { version = "4.5.31", features = ["derive"] }
 image = { version = "0.25.5", default-features = false }

--- a/ascii-img-cli/src/main.rs
+++ b/ascii-img-cli/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 
-use ascii_img::{Renderer, RendererCharacters};
+use ascii_img::{RendererConfig, RendererCharacters};
 use clap::Parser;
 use cli::Cli;
 use image::ImageError;
@@ -24,7 +24,7 @@ fn render(cli: Cli) -> Result<String, ImageError> {
             RendererCharacters::default()
         }
     };
-    let renderer = Renderer::default()
+    let renderer = RendererConfig::default()
         .width(cli.width)
         .height(cli.height)
         .invert(cli.invert.unwrap_or(false))

--- a/ascii-img/Cargo.toml
+++ b/ascii-img/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii-img"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 description = "Convert images to ASCII"
 license = "MPL-2.0"

--- a/ascii-img/src/lib.rs
+++ b/ascii-img/src/lib.rs
@@ -3,4 +3,4 @@
 extern crate alloc;
 
 pub mod renderer;
-pub use renderer::{Renderer, RendererCharacters, RendererType};
+pub use renderer::{RendererConfig, Renderer, RendererCharacters, RendererType};

--- a/ascii-img/src/renderer/ansi.rs
+++ b/ascii-img/src/renderer/ansi.rs
@@ -1,40 +1,25 @@
 //! ASCII renderer module
-#[allow(dead_code)]
 use super::{Renderer, common::*};
 use alloc::string::{String, ToString};
 use ansi_term::Colour;
-use image::{DynamicImage, Rgb};
+use image::Rgb;
 
-/// Renders the image as ANSI art
-pub fn render(options: &Renderer, image: &DynamicImage) -> String {
-    let image = process_options(options, image).into_rgb8();
+pub struct AnsiRenderer;
 
-    let mut string = string_from_size(image.width(), image.height());
-    let characters = options.characters.get();
-    let coeff = u8::MAX as f32 / (characters.len() - 1) as f32;
-    let mut last_pixel: Option<Rgb<u8>> = None;
-
-    for line in image.rows() {
-        for pixel in line {
-            if last_pixel != Some(*pixel) {
-                let normalized_pixel = saturate(pixel);
-                string.push_str(
-                    &Colour::RGB(
-                        normalized_pixel[0],
-                        normalized_pixel[1],
-                        normalized_pixel[2],
-                    )
-                    .prefix()
-                    .to_string(),
-                )
-            }
-            let luminance = linear_luma_from_rgb(pixel);
-            let character = characters[(luminance as f32 / coeff).round() as usize];
-            string.push(character);
-
-            last_pixel = Some(*pixel);
-        }
-        string.push('\n');
+#[allow(dead_code)]
+impl Renderer for AnsiRenderer {
+	/// Renders the image as ANSI art
+    fn render_pixel(&self, pixel: &Rgb<u8>, characters: &[char], coeff: f32) -> (String, char) {
+        let normalized_pixel = saturate(pixel);
+        let color_code = Colour::RGB(
+            normalized_pixel[0],
+            normalized_pixel[1],
+            normalized_pixel[2],
+        ).prefix().to_string();
+        
+        let luminance = linear_luma_from_rgb(pixel);
+        let character = characters[(luminance as f32 / coeff).round() as usize];
+        
+        (color_code, character)
     }
-    string
 }

--- a/ascii-img/src/renderer/ansi256.rs
+++ b/ascii-img/src/renderer/ansi256.rs
@@ -1,41 +1,25 @@
 //! ASCII 256 colors renderer module
-#[allow(dead_code)]
 use super::{Renderer, common::*};
 use alloc::string::{String, ToString};
-use ansi_colours::ColourExt;
 use ansi_term::Colour;
-use image::{DynamicImage, Rgb};
+use ansi_colours::ColourExt;
+use image::Rgb;
 
-/// Renders the image as ANSI art in 256 colors
-pub fn render(options: &Renderer, image: &DynamicImage) -> String {
-    let image = process_options(options, image).into_rgb8();
+pub struct Ansi256Renderer;
 
-    let mut string = string_from_size(image.width(), image.height());
-    let characters = options.characters.get();
-    let coeff = u8::MAX as f32 / (characters.len() - 1) as f32;
-    let mut last_pixel: Option<Rgb<u8>> = None;
-
-    for line in image.rows() {
-        for pixel in line {
-            if last_pixel != Some(*pixel) {
-                let normalized_pixel = saturate(pixel);
-                string.push_str(
-                    &Colour::approx_rgb(
-                        normalized_pixel[0],
-                        normalized_pixel[1],
-                        normalized_pixel[2],
-                    )
-                    .prefix()
-                    .to_string(),
-                )
-            }
-            let luminance = linear_luma_from_rgb(pixel);
-            let character = characters[(luminance as f32 / coeff).round() as usize];
-            string.push(character);
-
-            last_pixel = Some(*pixel);
-        }
-        string.push('\n');
+impl Renderer for Ansi256Renderer {
+	#[allow(dead_code)]
+    fn render_pixel(&self, pixel: &Rgb<u8>, characters: &[char], coeff: f32) -> (String, char) {
+        let normalized_pixel = saturate(pixel);
+        let color_code = Colour::approx_rgb(
+            normalized_pixel[0],
+            normalized_pixel[1],
+            normalized_pixel[2],
+        ).prefix().to_string();
+        
+        let luminance = linear_luma_from_rgb(pixel);
+        let character = characters[(luminance as f32 / coeff).round() as usize];
+        
+        (color_code, character)
     }
-    string
 }

--- a/ascii-img/src/renderer/common.rs
+++ b/ascii-img/src/renderer/common.rs
@@ -1,8 +1,7 @@
 //! Renderer common behavior module
 //! Contains function for use in other renderers
 
-use crate::Renderer;
-use alloc::string::String;
+use super::RendererConfig;
 use image::{DynamicImage, Rgb};
 
 /// Font aspect ratio
@@ -16,8 +15,8 @@ pub fn linear_luma_from_rgb(pixel: &Rgb<u8>) -> u8 {
 }
 
 /// Resizes an image with the `renderer`'s `width` and `height`
-fn resize(options: &Renderer, image: &DynamicImage) -> DynamicImage {
-    match (options.width, options.height) {
+pub fn resize(image: &DynamicImage, config: &RendererConfig) -> DynamicImage {
+    match (config.width, config.height) {
         (Some(width), Some(height)) => image.thumbnail_exact(width, height),
         (Some(width), None) => {
             image.thumbnail_exact(width, (width as f32 * FONT_ASPECT_RATIO) as u32)
@@ -30,16 +29,6 @@ fn resize(options: &Renderer, image: &DynamicImage) -> DynamicImage {
             (image.height() as f32 * FONT_ASPECT_RATIO) as u32,
         ),
     }
-}
-
-/// Apply common transformation to an image usinng the renderer options
-pub fn process_options(options: &Renderer, image: &DynamicImage) -> DynamicImage {
-    let mut image = resize(options, image);
-    if options.invert {
-        image.invert();
-    };
-
-    image
 }
 
 /// Returns a satuated copy of the provided pixel
@@ -57,11 +46,6 @@ pub fn saturate(pixel: &Rgb<u8>) -> Rgb<u8> {
         (g as f32 * coeff) as u8,
         (b as f32 * coeff) as u8,
     ])
-}
-
-/// Creates an empty string to store results for renderers
-pub fn string_from_size(width: u32, height: u32) -> String {
-    String::with_capacity((width * height) as usize)
 }
 
 #[cfg(test)]
@@ -82,18 +66,12 @@ mod test {
         let image = DynamicImage::new_luma8(100, 100);
 
         let resized_image = resize(
-            &Renderer::default().width(Some(150)).height(Some(150)),
             &image,
+			&RendererConfig::default().width(Some(150)).height(Some(150)),
         );
 
         assert_eq!(resized_image.width(), 150);
         assert_eq!(resized_image.height(), 150);
-    }
-
-    #[test]
-    fn process_options_test() {
-        let image = DynamicImage::new_luma8(100, 100);
-        process_options(&Renderer::default(), &image);
     }
 
     #[test]
@@ -106,11 +84,5 @@ mod test {
 
         let pixel = saturate(&Rgb([100, 100, 100]));
         assert_eq!((pixel[0], pixel[1], pixel[2]), (255, 255, 255));
-    }
-
-    #[test]
-    fn string_from_size_test() {
-        let string = string_from_size(20, 20);
-        assert_eq!(string.capacity(), 400);
     }
 }

--- a/ascii-img/src/renderer/unicode.rs
+++ b/ascii-img/src/renderer/unicode.rs
@@ -1,24 +1,25 @@
 //! ASCII renderer module
-#[allow(dead_code)]
-use super::{Renderer, common::*};
+use super::{Renderer, RendererConfig, common::*};
 use alloc::string::String;
-use image::DynamicImage;
+use image::{DynamicImage, Rgb};
 
-/// Renders the image as Unicode art
-pub fn render(options: &Renderer, image: &DynamicImage) -> String {
-    let image = process_options(options, image).to_luma8();
+pub struct UnicodeRenderer;
 
-    let mut string = string_from_size(image.width(), image.height());
-    let characters = options.characters.get();
-    let coeff = u8::MAX as f32 / (characters.len() - 1) as f32;
-
-    for line in image.rows() {
-        for pixel in line {
-            let luminance = pixel[0];
-            let character = characters[(luminance as f32 / coeff).round() as usize];
-            string.push(character)
-        }
-        string.push('\n');
+impl Renderer for UnicodeRenderer {
+	#[allow(dead_code)]
+    fn render_pixel(&self, pixel: &Rgb<u8>, characters: &[char], coeff: f32) -> (String, char) {
+        let luminance = linear_luma_from_rgb(pixel);
+        let character = characters[(luminance as f32 / coeff).round() as usize];
+        (String::new(), character)
     }
-    string
+
+    fn preprocess_image(&self, image: &DynamicImage, config: &RendererConfig) -> DynamicImage {
+        // Unicode renderer works with grayscale images
+        let mut image = resize(image, config);
+        if config.invert {
+            image.invert();
+        };
+
+        image.to_luma8().into()
+    }
 }


### PR DESCRIPTION
### Description
#### Notes to self LMAO:
I've broken the API once again by moving some `common` module functions to a new trait: `Renderer`.
The `Renderer` struct has been renamed to `RendererConfig` and some tests were deleted.

THIS P.R. WAS WRITTEN WITH AI ASSISTANCE (thanks Copilot)

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
