### PR TITLE
feat!: Better API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,12 +86,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "av1-grain"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
+checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -192,9 +192,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitreader"
@@ -255,9 +255,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -271,7 +271,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34e221e91c7eb5e8315b5c9cf1a61670938c0626451f954a51693ed44b37f45"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
@@ -282,9 +292,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -292,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -373,19 +383,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80c3f80814db85397819d464bb553268992c393b4b3b5554b89c1655996d5926"
 dependencies = [
  "av-data",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "dav1d-sys",
  "static_assertions",
 ]
 
 [[package]]
 name = "dav1d-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecb1c5e8f4dc438eedc1b534a54672fb0e0a56035dae6b50162787bd2c50e95"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -728,6 +738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +885,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "simd_helpers",
- "system-deps",
+ "system-deps 6.2.2",
  "thiserror",
  "v_frame",
  "wasm-bindgen",
@@ -921,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "serde"
@@ -1010,7 +1026,20 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb"
+dependencies = [
+ "cfg-expr 0.20.0",
  "heck",
  "pkg-config",
  "toml",
@@ -1022,6 +1051,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "thiserror"
@@ -1198,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "winapi"
@@ -1312,7 +1347,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/ascii-img-cli/Cargo.toml
+++ b/ascii-img-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ascii-img-cli"
 version = "0.1.3"
-edition = "2024"
+edition = "2018"
 description = "Command-line tool for using ascii-img"
 license = "MPL-2.0"
 authors = ["4yman-0"]

--- a/ascii-img-cli/src/main.rs
+++ b/ascii-img-cli/src/main.rs
@@ -18,18 +18,19 @@ fn render(cli: Cli) -> Result<String, ImageError> {
             if characters == "builtin" {
                 RendererCharacters::builtin()
             } else {
-                RendererCharacters::from_string(characters.as_str())
+                RendererCharacters::custom_from(characters.as_str())
             }
         } else {
             RendererCharacters::default()
         }
     };
-    let renderer = Renderer::default()
-        .width(cli.width)
-        .height(cli.height)
-        .invert(cli.invert.unwrap_or(false))
-        .characters(characters)
-        .renderer_type(cli.renderer_type.unwrap_or_default().into());
+    let result = Renderer::default()
+        .set_width(cli.width)
+        .set_height(cli.height)
+        .set_invert(cli.invert.unwrap_or(false))
+        .set_characters(characters)
+        .set_renderer_type(cli.renderer_type.unwrap_or_default().into())
+        .render(&image);
 
-    Ok(renderer.render(&image))
+    Ok(result)
 }

--- a/ascii-img/Cargo.toml
+++ b/ascii-img/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ascii-img"
 version = "0.2.2"
-edition = "2024"
+edition = "2018"
 description = "Convert images to ASCII"
 license = "MPL-2.0"
 authors = ["4yman-0"]

--- a/ascii-img/src/renderer/ansi.rs
+++ b/ascii-img/src/renderer/ansi.rs
@@ -1,6 +1,6 @@
 //! ASCII renderer module
 #[allow(dead_code)]
-use super::{Renderer, common::*};
+use super::{common::*, Renderer};
 use alloc::string::{String, ToString};
 use ansi_term::Colour;
 use image::{DynamicImage, Rgb};
@@ -10,7 +10,7 @@ pub fn render(options: &Renderer, image: &DynamicImage) -> String {
     let image = process_options(options, image).into_rgb8();
 
     let mut string = string_from_size(image.width(), image.height());
-    let characters = options.characters.get();
+    let characters = options.characters().get();
     let coeff = u8::MAX as f32 / (characters.len() - 1) as f32;
     let mut last_pixel: Option<Rgb<u8>> = None;
 
@@ -28,7 +28,7 @@ pub fn render(options: &Renderer, image: &DynamicImage) -> String {
                     .to_string(),
                 )
             }
-            let luminance = linear_luma_from_rgb(pixel);
+            let luminance = linear_luma_from_rgb(pixel).unwrap();
             let character = characters[(luminance as f32 / coeff).round() as usize];
             string.push(character);
 

--- a/ascii-img/src/renderer/ansi256.rs
+++ b/ascii-img/src/renderer/ansi256.rs
@@ -1,6 +1,6 @@
 //! ASCII 256 colors renderer module
 #[allow(dead_code)]
-use super::{Renderer, common::*};
+use super::{common::*, Renderer};
 use alloc::string::{String, ToString};
 use ansi_colours::ColourExt;
 use ansi_term::Colour;
@@ -11,7 +11,7 @@ pub fn render(options: &Renderer, image: &DynamicImage) -> String {
     let image = process_options(options, image).into_rgb8();
 
     let mut string = string_from_size(image.width(), image.height());
-    let characters = options.characters.get();
+    let characters = options.characters().get();
     let coeff = u8::MAX as f32 / (characters.len() - 1) as f32;
     let mut last_pixel: Option<Rgb<u8>> = None;
 
@@ -29,7 +29,7 @@ pub fn render(options: &Renderer, image: &DynamicImage) -> String {
                     .to_string(),
                 )
             }
-            let luminance = linear_luma_from_rgb(pixel);
+            let luminance = linear_luma_from_rgb(pixel).unwrap();
             let character = characters[(luminance as f32 / coeff).round() as usize];
             string.push(character);
 

--- a/ascii-img/src/renderer/common.rs
+++ b/ascii-img/src/renderer/common.rs
@@ -3,6 +3,7 @@
 
 use crate::Renderer;
 use alloc::string::String;
+use core::convert::TryInto;
 use image::{DynamicImage, Rgb};
 
 /// Font aspect ratio

--- a/ascii-img/src/renderer/mod.rs
+++ b/ascii-img/src/renderer/mod.rs
@@ -1,5 +1,4 @@
 //! Renderer modoule
-//! Defines the `RendererType` enum for listing renderers and the `Renderer` struct for storing generic renderer data
 //! # Example
 //! ```
 //! use image::DynamicImage;
@@ -24,9 +23,12 @@ use image::DynamicImage;
 const DEFAULT_CHARS: &[char] = &[' ', '.', '-', ':', '=', '*', '+', '#', '%', '@'];
 // TODO: better characters for ANSI and Unicode
 
+/// Abstacts an array of characters, for use in [`Renderer`](struct.Renderer.html)
 pub enum RendererCharacters {
+    /// The built-in array of characters
     Builtin,
-    String(Vec<char>),
+    /// A custom array of characters
+    Custom(Vec<char>),
 }
 
 impl Default for RendererCharacters {
@@ -37,7 +39,7 @@ impl Default for RendererCharacters {
 
 #[allow(dead_code)]
 impl RendererCharacters {
-    /// Return the built-in characters in the form of a zero-sized enum variant
+    /// Return the built-in character array in the form of an empty enum variant
     /// ```
     /// use ascii_img::RendererCharacters;
     /// let renderer_chars = RendererCharacters::builtin();
@@ -46,16 +48,16 @@ impl RendererCharacters {
         Self::Builtin
     }
 
-    /// Returns a new `Vec<char>` from the string
+    /// Returns an instance of `RendererCharacters` from a string-like reference
     /// ```
     /// use ascii_img::RendererCharacters;
-    /// let renderer_chars = RendererCharacters::from_string(" .-#");
+    /// let renderer_chars = RendererCharacters::custom_from(" .-#");
     /// ```
-    pub fn from_string(string: &str) -> Self {
-        Self::String(string.chars().collect())
+    pub fn custom_from<T: AsRef<str>>(string: T) -> Self {
+        Self::Custom(string.as_ref().chars().collect())
     }
 
-    /// Creates a new `Vec<char>` from contained data.
+    /// Returns a `Vec<char>` from contained data.
     /// ```
     /// use ascii_img::RendererCharacters;
     /// let renderer_chars = RendererCharacters::builtin();
@@ -64,23 +66,28 @@ impl RendererCharacters {
     pub fn get(&self) -> Vec<char> {
         match self {
             Self::Builtin => Vec::from(DEFAULT_CHARS),
-            Self::String(characters) => characters.clone(),
+            Self::Custom(characters) => characters.clone(),
         }
     }
 }
 
 #[derive(Clone)]
+/// An enum of supported renderer types
 pub enum RendererType {
     #[cfg(feature = "ansi-renderer")]
+    /// The ANSI renderer
     Ansi,
 
     #[cfg(feature = "ansi256-renderer")]
+    /// The ANSI 256 colors renderer
     Ansi256,
 
     #[cfg(feature = "unicode-renderer")]
+    /// The Unicode renderer
     Unicode,
 }
 
+/// Stores generic renderer data
 pub struct Renderer {
     width: Option<u32>,
     height: Option<u32>,
@@ -117,27 +124,47 @@ impl Renderer {
         }
     }
 
-    pub fn width(mut self, width: Option<u32>) -> Self {
-        self.width = width;
+    pub fn width(&self) -> Option<u32> {
+        self.width
+    }
+
+    pub fn height(&self) -> Option<u32> {
+        self.height
+    }
+
+    pub fn invert(&self) -> bool {
+        self.invert
+    }
+
+    pub fn characters(&self) -> &RendererCharacters {
+        &self.characters
+    }
+
+    pub fn renderer_type(&self) -> &RendererType {
+        &self.renderer_type
+    }
+
+    pub fn set_width<T: Into<Option<u32>>>(&mut self, width: T) -> &mut Self {
+        self.width = width.into();
         self
     }
 
-    pub fn height(mut self, height: Option<u32>) -> Self {
-        self.height = height;
+    pub fn set_height<T: Into<Option<u32>>>(&mut self, height: T) -> &mut Self {
+        self.height = height.into();
         self
     }
 
-    pub fn invert(mut self, invert: bool) -> Self {
+    pub fn set_invert(&mut self, invert: bool) -> &mut Self {
         self.invert = invert;
         self
     }
 
-    pub fn characters(mut self, characters: RendererCharacters) -> Self {
+    pub fn set_characters(&mut self, characters: RendererCharacters) -> &mut Self {
         self.characters = characters;
         self
     }
 
-    pub fn renderer_type(mut self, renderer_type: RendererType) -> Self {
+    pub fn set_renderer_type(&mut self, renderer_type: RendererType) -> &mut Self {
         self.renderer_type = renderer_type;
         self
     }
@@ -150,10 +177,10 @@ mod test {
     #[test]
     fn renderer_build_test() {
         let _renderer = Renderer::default()
-            .width(Some(100))
-            .height(Some(100))
-            .invert(true)
-            .characters(RendererCharacters::default())
-            .renderer_type(RendererType::Unicode);
+            .set_width(100_u32)
+            .set_height(100_u32)
+            .set_invert(true)
+            .set_characters(RendererCharacters::default())
+            .set_renderer_type(RendererType::Unicode);
     }
 }

--- a/ascii-img/src/renderer/unicode.rs
+++ b/ascii-img/src/renderer/unicode.rs
@@ -1,6 +1,6 @@
 //! ASCII renderer module
 #[allow(dead_code)]
-use super::{Renderer, common::*};
+use super::{common::*, Renderer};
 use alloc::string::String;
 use image::DynamicImage;
 
@@ -9,7 +9,7 @@ pub fn render(options: &Renderer, image: &DynamicImage) -> String {
     let image = process_options(options, image).to_luma8();
 
     let mut string = string_from_size(image.width(), image.height());
-    let characters = options.characters.get();
+    let characters = options.characters().get();
     let coeff = u8::MAX as f32 / (characters.len() - 1) as f32;
 
     for line in image.rows() {


### PR DESCRIPTION
### Description
- Decrease Rust edition to 2018 (Also decreases MSRV)
- Rename `RendererCharacters::from_string` to `custom_from`
- Add getter functions to `Renderer` and rename setter fucntion to `set_*`
- Update `common::linear_luma_from_rgb` to return errors
- Update `common::resize` to take a tuple of `Option<u32>` instead of an entire `Renderer`
- Update Documentation
### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
  NOTE: *Updated
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
